### PR TITLE
Feature/wiki path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ SmashingDocs.config do |c|
   c.output_file   = 'smashing_docs/api_docs.md'
   c.run_all       = true
   c.auto_push     = false
+  c.wiki_folder   = nil
 end
 ```
 
@@ -59,10 +60,9 @@ end
 Set the `c.run_all` line to `false` in `rails_helper.rb`
 ```ruby
 SmashingDocs.config do |c|
-  c.template_file = 'smashing_docs/template.md'
-  c.output_file   = 'smashing_docs/api_docs.md'
+  # configs
   c.run_all       = false
-  c.auto_push     = false
+  # configs
 end
 ```
 
@@ -86,6 +86,7 @@ class ActiveSupport::TestCase
     c.output_file   = 'smashing_docs/api_docs.md'
     c.run_all       = true
     c.auto_push     = false
+    c.wiki_folder   = nil
   end
   # More code
 end
@@ -103,10 +104,9 @@ MiniTest::Unit.after_tests { SmashingDocs.finish! }
 Set the `c.run_all` line to `false` in `test_helper.rb`
 ```ruby
 SmashingDocs.config do |c|
-  c.template_file = 'smashing_docs/template.md'
-  c.output_file   = 'smashing_docs/api_docs.md'
+  # configs
   c.run_all       = false
-  c.auto_push     = false
+  # configs
 end
 ```
 
@@ -176,20 +176,30 @@ SmashingDocs can automatically push your generated docs to your project wiki.
 
   Your folder structure should be
 
-    ../projects/my_rails_app
+    ../projects/rails_app
 
     ../projects/my_rails_app.wiki
 
-  2. Set auto_push to true in `rails_helper.rb` or `test_helper.rb`
+  2. Set the name of your wiki folder (do **not** include '.wiki')
+
+    ``` ruby
+      SmashingDocs.config do |c|
+        # configs
+        c.wiki_folder = "my_rails_app"
+      end
+    ```
+
+  3. Set auto_push to true in `rails_helper.rb` or `test_helper.rb`
 
     ``` ruby
       SmashingDocs.config do |c|
         # configs
         c.auto_push = true
+        # configs
       end
     ```
 
-  3. Build your docs with `rails g smashing_documentation:build_docs`
+  4. Build your docs with `rails g smashing_documentation:build_docs`
 
 #### Generate Docs on Every Test Suite Run
 

--- a/gem_rspec/base_spec.rb
+++ b/gem_rspec/base_spec.rb
@@ -117,8 +117,16 @@ RSpec.describe SmashingDocs do
   end
 
   describe "#app_name" do
-    it "returns the name of the app it is installed in" do
-      expect(SmashingDocs.current.send(:app_name)).to eq("smashing_docs")
+    context "when wiki_folder config is set" do
+      let!(:config) { SmashingDocs.config { |c| c.wiki_folder = "different_folder" } }
+      it "returns the name of the wiki folder" do
+        expect(SmashingDocs.current.send(:app_name)).to eq("different_folder")
+      end
+    end
+    context "when wiki_folder config is nil" do
+      it "returns the name of the app it is installed in" do
+        expect(SmashingDocs.current.send(:app_name)).to eq("smashing_docs")
+      end
     end
   end
 

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -114,6 +114,7 @@ end
 private
 
 def app_name
+  return self.class::Conf.wiki_folder if self.class::Conf.wiki_folder
   directory = `pwd`
   directory.match(/\w+\n/).to_s.gsub(/\n/, "")
 end

--- a/lib/conf.rb
+++ b/lib/conf.rb
@@ -1,8 +1,8 @@
 class SmashingDocs::Conf
   class << self
-    attr_accessor :template_file, :output_file, :auto_push, :run_all
+    attr_accessor :template_file, :output_file, :auto_push, :run_all, :wiki_folder
     @output_file = 'documentation.md'
-    
+
     def template
       raise 'You must set a template file.' unless template_file
       File.read(template_file)

--- a/lib/generators/smashing_documentation/install_generator.rb
+++ b/lib/generators/smashing_documentation/install_generator.rb
@@ -75,6 +75,7 @@ module SmashingDocumentation
                  "  c.output_file   = 'smashing_docs/api_docs.md'\n"\
                  "  c.run_all       = true\n"\
                  "  c.auto_push     = false\n"\
+                 "  c.wiki_folder     = nil\n"\
                  "end\n"
         if using_minitest?
           insert_into_file(@config_file, config, after: "class ActiveSupport::TestCase\n")

--- a/smashing_docs.gemspec
+++ b/smashing_docs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.summary = "Uses your test cases to write example documentation for your API."
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.version = '1.2.1'
+  s.version = '1.3.1'
 
   s.add_development_dependency "bundler", "~> 1.11"
   s.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
### Why?
Because sometimes local folders and github repo names don't coincide

### What Changed?
Added a config to set the wiki folder name manually
Updated README with usage instructions for the new config