### PR TITLE
Feature/shorten namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation differs for RSpec/Minitest, so scroll to the appropriate section fo
 
 After you bundle, run:
 
-`rails generate smashing_documentation:install`
+`rails g docs:install`
 
 SmashingDocs will be configured to run on all your controller tests with the default
 template.
@@ -25,7 +25,7 @@ If you're using RSpec and you haven't required `rails_helper` in your tests, do 
 
 #### To generate your docs
 
-Run `rails g smashing_documentation:build_docs`, and your docs will be waiting for you in the `smashing_docs` folder.
+Run `rails g docs:build_docs`, and your docs will be waiting for you in the `smashing_docs` folder.
 
 ## Manual RSpec Installation
 
@@ -199,7 +199,7 @@ SmashingDocs can automatically push your generated docs to your project wiki.
       end
     ```
 
-  4. Build your docs with `rails g smashing_documentation:build_docs`
+  4. Build your docs with `rails g docs:build_docs`
 
 #### Generate Docs on Every Test Suite Run
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 In your gemfile add the following to your test group:
 
-`gem 'smashing_docs', '~> 0.0.3'`
+`gem 'smashing_docs', '~> 1.3.1'`
 
 Installation differs for RSpec/Minitest, so scroll to the appropriate section for guidance.
 

--- a/lib/generators/docs/build_docs_generator.rb
+++ b/lib/generators/docs/build_docs_generator.rb
@@ -1,5 +1,5 @@
 require 'rails/generators'
-module SmashingDocumentation
+module Docs
   module Generators
     class BuildDocsGenerator < Rails::Generators::Base
       source_root File.expand_path("../../../templates/", __FILE__)

--- a/lib/generators/docs/install_generator.rb
+++ b/lib/generators/docs/install_generator.rb
@@ -1,5 +1,5 @@
 require 'rails/generators'
-module SmashingDocumentation
+module Docs
   module Generators
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path("../../../templates/", __FILE__)


### PR DESCRIPTION
### Why?
Because `rails generate smashing_documentation:build_docs` is loooooong!

### What Changed?
Shortened the namespace
Commands are now `rails generate docs:install` and `rails generate docs:build_docs`
Updated README to reflect these changes