### PR TITLE
Fix indentation. Handle ERB template errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smashing_docs (1.1.0)
+    smashing_docs (1.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 In your gemfile add the following to your test group:
 
-`gem 'smashing_docs', '~> 1.3.1'`
+`gem 'smashing_docs', '~> 1.3.2'`
 
 Installation differs for RSpec/Minitest, so scroll to the appropriate section for guidance.
 

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -65,12 +65,16 @@ class SmashingDocs
 
   def write_to_file
     File.open(self.class::Conf.output_file, 'a') do |file|
-      @tests.each do |test|
-        begin
-          file.write(test.compile_template)
-        rescue
-          # Cry deeply
-        end
+      output_compiled_template(file)
+    end
+  end
+
+  def output_compiled_template(file)
+    @tests.each do |test|
+      begin
+        file.write(test.compile_template)
+      rescue
+        # Cry deeply
       end
     end
   end

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -66,7 +66,11 @@ class SmashingDocs
   def write_to_file
     File.open(self.class::Conf.output_file, 'a') do |file|
       @tests.each do |test|
-        file.write(test.compile_template)
+        begin
+          file.write(test.compile_template)
+        rescue
+          # Cry deeply
+        end
       end
     end
   end

--- a/lib/generators/docs/install_generator.rb
+++ b/lib/generators/docs/install_generator.rb
@@ -75,7 +75,7 @@ module Docs
                  "  c.output_file   = 'smashing_docs/api_docs.md'\n"\
                  "  c.run_all       = true\n"\
                  "  c.auto_push     = false\n"\
-                 "  c.wiki_folder     = nil\n"\
+                 "  c.wiki_folder   = nil\n"\
                  "end\n"
         if using_minitest?
           insert_into_file(@config_file, config, after: "class ActiveSupport::TestCase\n")

--- a/smashing_docs.gemspec
+++ b/smashing_docs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.summary = "Uses your test cases to write example documentation for your API."
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.version = '1.3.1'
+  s.version = '1.3.2'
 
   s.add_development_dependency "bundler", "~> 1.11"
   s.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
### Why?
Because SmashingDocs doesn't get along with rspec_controller_helpers
Because the config upset Rubocop

### What Changed?
Added temporary error handling so SD can be used with rspec_controller_helpers while the issue is investigated
Removed bonus indentation from `wiki_folder` config