### PR TITLE
Set test environment in docs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 In your gemfile add the following to your test group:
 
-`gem 'smashing_docs', '~> 1.3.2'`
+`gem 'smashing_docs', '~> 1.3.3'`
 
 Installation differs for RSpec/Minitest, so scroll to the appropriate section for guidance.
 

--- a/lib/generators/docs/build_docs_generator.rb
+++ b/lib/generators/docs/build_docs_generator.rb
@@ -2,6 +2,7 @@ require 'rails/generators'
 module Docs
   module Generators
     class BuildDocsGenerator < Rails::Generators::Base
+      ENV['RAILS_ENV'] = 'test'
       source_root File.expand_path("../../../templates/", __FILE__)
       def build_docs
         destination = "spec/spec_helper.rb"

--- a/smashing_docs.gemspec
+++ b/smashing_docs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.summary = "Uses your test cases to write example documentation for your API."
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.version = '1.3.2'
+  s.version = '1.3.3'
 
   s.add_development_dependency "bundler", "~> 1.11"
   s.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
### Why?
Because SmashingDocs was using data from the `development` database

### What Changed?
The docs generator has been configured to use the test environment